### PR TITLE
Update time on settings change and awake from sleep

### DIFF
--- a/src/Services/TimeManager.vala
+++ b/src/Services/TimeManager.vala
@@ -84,7 +84,7 @@ public class DateTime.Services.TimeManager : Gtk.Calendar {
             add_timeout (update_fast);
 
             return false;
-        });    
+        });
     }
 
     public string format (string format) {

--- a/src/Services/TimeManager.vala
+++ b/src/Services/TimeManager.vala
@@ -77,10 +77,8 @@ public class DateTime.Services.TimeManager : Gtk.Calendar {
         }
 
         timeout_id = Timeout.add (timeout, () => {
-            warning ("Update");
             update_current_time ();
             minute_changed ();
-
             add_timeout (update_fast);
 
             return false;


### PR DESCRIPTION
Fixes #3 and fixes #16 .

To resolve the time not being updated when the settings are being changed, the indicator watches the D-BUS daemon that is associated with the time settings. It only runs when the settings are being changed. While running, the indicator updates its time more frequently.

The time being slow to update after waking from sleep was due to the fact that the timeout is calculated based upon the number of seconds until the minute changes.

If you put the computer to sleep 15 seconds after the minute has changed, it will take 45 seconds after waking for the clock to update. This is also the cause of the difference between the wingpanel time and the system time.

This branch resolves both of these issue by triggering an update as soon as the system wakes from sleep and ensuring that the calculated time to the next minute change is always up to date.