### PR TITLE
Replace cairo with Gtk.CSS

### DIFF
--- a/src/Widgets/calendar/Calendar.vala
+++ b/src/Widgets/calendar/Calendar.vala
@@ -73,27 +73,5 @@ namespace DateTime.Widgets {
                 warning ("Unable to start calendar, error: %s", e.message);
             }
         }
-
-        public override bool draw (Cairo.Context cr) {
-            base.draw (cr);
-            Gtk.Allocation size;
-            cal.get_allocation (out size);
-            cr.set_source_rgba (0.0, 0.0, 0.0, 0.25);
-            cr.set_line_width (1.0);
-            int y = 59;
-            int height = size.height - 25;
-            cr.move_to (4.5, y + 0.5);
-            cr.line_to (size.width - 4.5, y + 0.5);
-            cr.curve_to (size.width - 4.5, y + 0.5, size.width - 0.5, y + 0.5, size.width - 0.5, y + 4.5);
-            cr.line_to (size.width - 0.5, y + height - 4.5);
-            cr.curve_to (size.width - 0.5, y + height - 4.5, size.width - 0.5, y + height - 0.5, size.width - 4.5, y + height - 0.5);
-            cr.line_to (4.5, y + height - 0.5);
-            cr.curve_to (4.5, y + height - 0.5, 0.5, y + height - 0.5, 0.5, y + height - 4.5);
-            cr.line_to (0.5, y + 4.5);
-            cr.curve_to (0.5, y + 4.5, 0.5, y + 0.5, 4.5, y + 0.5);
-            cr.stroke ();
-
-            return false;
-        }
     }
 }

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -39,12 +39,9 @@ namespace DateTime.Widgets {
         private GridDay selected_gridday;
 
         public Grid () {
-            /* Gtk.Grid properties */
             insert_column (7);
             set_column_homogeneous (true);
             set_row_homogeneous (true);
-            column_spacing = 0;
-            row_spacing = 0;
 
             data = new Gee.HashMap<uint, GridDay> ();
             events |= Gdk.EventMask.SCROLL_MASK;

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -28,7 +28,6 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         .circular {
             border-radius: 50%;
         }
-
     """;
 
     /*

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -24,6 +24,13 @@
  */
 public class DateTime.Widgets.GridDay : Gtk.EventBox {
 
+    const string DAY_CSS = """
+        .circular {
+            border-radius: 50%;
+        }
+
+    """;
+
     /*
      * Event emitted when the day is double clicked or the ENTER key is pressed.
      */
@@ -39,19 +46,24 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         this.id = id;
 
         label = new Gtk.Label ("");
-        set_size_request (32, 25);
+        set_size_request (32, 32);
+
+        var provider = new Gtk.CssProvider ();
+        try {
+            provider.load_from_data (DAY_CSS, DAY_CSS.length);
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {
+            critical (e.message);
+        }
+
+        get_style_context ().add_class ("circular");
+
         // EventBox Properties
         can_focus = true;
         events |= Gdk.EventMask.BUTTON_PRESS_MASK;
         events |= Gdk.EventMask.KEY_PRESS_MASK;
         events |= Gdk.EventMask.SMOOTH_SCROLL_MASK;
-        var style_provider = Util.Css.get_css_provider ();
-        get_style_context ().add_provider (style_provider, 600);
-        get_style_context ().add_class ("cell");
 
-        label.halign = Gtk.Align.CENTER;
-        label.valign = Gtk.Align.CENTER;
-        label.get_style_context ().add_provider (style_provider, 600);
         label.name = "date";
 
         add (label);
@@ -61,33 +73,6 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         button_press_event.connect (on_button_press);
         key_press_event.connect (on_key_press);
         scroll_event.connect ((event) => {return Util.on_scroll_event (event);});
-    }
-
-    public override bool draw (Cairo.Context cr) {
-        base.draw (cr);
-        Gtk.Allocation size;
-        get_allocation (out size);
-
-        cr.set_source_rgba (0.0, 0.0, 0.0, 0.25);
-        cr.set_line_width (1.0);
-
-        // Draw left and top black strokes
-        if (id % 7 == 0) {
-            cr.move_to (0.5, 0.5);
-        } else {
-            cr.move_to (0.5, size.height); // start in bottom left. 0.5 accounts for cairo's default stroke offset of 1/2 pixels
-            cr.line_to (0.5, 0.5); // move to upper left corner
-        }
-        if (id > 6) {
-            cr.line_to (size.width + 0.5, 0.5); // move to upper right corner
-        }
-        cr.stroke ();
-
-        // Draw inner highlight stroke
-        cr.rectangle (1, 1, size.width - 1, size.height - 1);
-        cr.set_source_rgba (1.0, 1.0, 1.0, 0.2);
-        cr.stroke ();
-        return false;
     }
 
     public void update_date (GLib.DateTime date) {

--- a/src/Widgets/calendar/Header.vala
+++ b/src/Widgets/calendar/Header.vala
@@ -45,10 +45,7 @@ public class Header : Gtk.EventBox {
         for (int c = 0; c < 7; c++) {
             labels[c] = new Gtk.Label ("");
             labels[c].hexpand = true;
-            labels[c].margin_top = 4;
-            labels[c].margin_bottom = 2;
             var label_grid = new Gtk.Grid ();
-            // label_grid.draw.connect (on_draw);
             label_grid.add (labels[c]);
             header_grid.attach (label_grid, c, 0, 1, 1);
         }
@@ -60,6 +57,7 @@ public class Header : Gtk.EventBox {
         var date = Util.strip_time(new GLib.DateTime.now_local ());
         date = date.add_days (week_starts_on - date.get_day_of_week ());
         foreach (var label in labels) {
+            label.get_style_context ().add_class ("h4");
             label.label = date.format ("%a");
             date = date.add_days (1);
         }

--- a/src/Widgets/calendar/WeekLabels.vala
+++ b/src/Widgets/calendar/WeekLabels.vala
@@ -18,11 +18,8 @@
  * Authored by: Maxwell Barvian
  *              Corentin Noël <corentin@elementaryos.org>
  */
- namespace DateTime.Widgets {
-/**
- * Represent the week labels at the left side of the grid.
- */
-public class WeekLabels : Gtk.Revealer {
+
+public class DateTime.Widgets.WeekLabels : Gtk.Revealer {
 
     private Gtk.Grid day_grid;
     private Gtk.Label[] labels;
@@ -34,15 +31,10 @@ public class WeekLabels : Gtk.Revealer {
         day_grid = new Gtk.Grid ();
         set_nr_of_weeks (5);
         day_grid.insert_row (1);
-        day_grid.set_column_homogeneous (true);
-        day_grid.set_row_homogeneous (true);
-        day_grid.row_spacing = 0;
+        day_grid.attach (new Gtk.Separator (Gtk.Orientation.VERTICAL), 1, 0, 1, 6);
+        day_grid.column_spacing = 9;
         day_grid.show ();
 
-        var style_provider = Util.Css.get_css_provider ();
-
-        // EventBox properties
-        day_grid.get_style_context().add_provider (style_provider, 600);
         day_grid.get_style_context().add_class ("weeks");
 
         add (day_grid);
@@ -62,6 +54,8 @@ public class WeekLabels : Gtk.Revealer {
             int days_to_add = (8 - next.get_day_of_week()) % 7;
             next = next.add_days(days_to_add);
             foreach (var label in labels) {
+                label.get_style_context ().add_class ("h4");
+                label.height_request = 30;
                 label.label = next.get_week_of_year ().to_string();
                 next = next.add_weeks (1);
             }
@@ -100,24 +94,4 @@ public class WeekLabels : Gtk.Revealer {
             labels[c].show ();
         }
     }
-
-    public override bool draw (Cairo.Context cr) {
-        base.draw (cr);
-        if (!child_revealed)
-            return false;
-        Gtk.Allocation size;
-        get_allocation (out size);
-        cr.set_source_rgba (0.0, 0.0, 0.0, 0.25);
-        cr.set_line_width (1.0);
-        cr.set_antialias (Cairo.Antialias.NONE);
-        cr.move_to (size.width - 0.5, 0.5);
-        cr.line_to (size.width - 0.5, size.height);
-        for (int i = 1; i < size.height / 25; i++) {
-            cr.move_to (0, i * 25 + 0.5);
-            cr.line_to (size.width + 0.5, i * 25 + 0.5);
-        }
-        cr.stroke ();
-        return false;
-    }
-}
 }


### PR DESCRIPTION
Replaces a bunch of unsavory Cairo with a little bit of Gtk.CSS

Fixes #20 

![screenshot from 2017-04-26 15 03 40](https://cloud.githubusercontent.com/assets/7277719/25459131/99b4869a-2a91-11e7-9bf2-03b4b68939a5.png)

