### PR TITLE
Make the top month & year translatable

### DIFF
--- a/src/Widgets/calendar/ControlHeader.vala
+++ b/src/Widgets/calendar/ControlHeader.vala
@@ -27,10 +27,10 @@ namespace DateTime.Widgets {
             Object (orientation : Gtk.Orientation.HORIZONTAL);
             var left_button = new Gtk.Button.from_icon_name ("pan-start-symbolic");
             var right_button = new Gtk.Button.from_icon_name ("pan-end-symbolic");
-            var center_button = new Gtk.Button.with_label (new GLib.DateTime.now_local ().format ("%B %Y"));
+            var center_button = new Gtk.Button.with_label (new GLib.DateTime.now_local ().format (_("%B %Y")));
             CalendarModel.get_default ().parameters_changed.connect (() => {
                 var date = CalendarModel.get_default ().month_start;
-                center_button.set_label (date.format ("%B %Y"));
+                center_button.set_label (date.format (_("%B %Y")));
             });
             left_button.clicked.connect (() => {
                 left_clicked ();


### PR DESCRIPTION

![virtualbox_eos_09_05_2018_19_11_27](https://user-images.githubusercontent.com/26003928/39809515-f47c518e-53bc-11e8-8831-ecab49080944.png)

The month and year string (in this screenshot above, "May 2018") was not translatable. I fixed it.
