### PR TITLE
Remove the explicit refocus

### DIFF
--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -143,20 +143,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         weeks.update (model.data_range.first_dt, model.num_weeks);
         grid.set_range (model.data_range, model.month_start);
 
-        // keep focus date on the same day of the month
-        if (selected_date != null) {
-            var month = (GLib.DateMonth)model.month_start.get_month ();
-            var year = (GLib.DateYear)model.month_start.get_year ();
-            int days_in_month = GLib.Date.get_days_in_month (month, year);
-            GLib.DateTime bumpdate;
-            if (selected_date.get_day_of_month () > days_in_month) {
-                bumpdate = model.month_start.add_days (days_in_month - 1);
-            } else {
-                bumpdate = model.month_start.add_days (selected_date.get_day_of_month() - 1);
-            }
-            grid.focus_date (bumpdate);
-        }
-
         if (previous_first != null) {
             if (previous_first.compare (grid.grid_range.first_dt) == -1) {
                 stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT;

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -105,7 +105,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         if (!start.equal (calmodel.month_start))
             calmodel.month_start = start;
         sync_with_model ();
-        grid.focus_date (today);
     }
 
     //--- Signal Handlers ---//

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2011–2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2011–2018 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2011-2015 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2011–2019 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -158,7 +158,7 @@ namespace DateTime.Widgets {
         GridDay update_day (GridDay day, GLib.DateTime new_date, GLib.DateTime today, GLib.DateTime month_start) {
             if (new_date.get_day_of_year () == today.get_day_of_year () && new_date.get_year () == today.get_year ()) {
                 day.name = "today";
-                day.get_style_context ().add_class ("today");
+                day.get_style_context ().add_class ("accent");
                 day.set_receives_default (true);
             }
             if (new_date.get_month () == month_start.get_month ()) {

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -158,7 +158,7 @@ namespace DateTime.Widgets {
         GridDay update_day (GridDay day, GLib.DateTime new_date, GLib.DateTime today, GLib.DateTime month_start) {
             if (new_date.get_day_of_year () == today.get_day_of_year () && new_date.get_year () == today.get_year ()) {
                 day.name = "today";
-                day.get_style_context ().add_class ("accent");
+                day.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
                 day.set_receives_default (true);
             }
             if (new_date.get_month () == month_start.get_month ()) {

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -69,17 +69,6 @@ namespace DateTime.Widgets {
             }
         }
 
-        public void focus_date (GLib.DateTime date) {
-            debug (@"Setting focus to @ $(date)");
-            var date_hash = day_hash (date);
-
-            if (data.has_key (date_hash) == true) {
-                var day_widget = data.get (date_hash);
-                day_widget.grab_focus ();
-                on_day_focus_in (day_widget);
-            }
-        }
-
         /**
          * Sets the given range to be displayed in the grid. Note that the number of days
          * must remain the same.

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2011–2018 elementary, Inc. (https://elementary.io)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -158,6 +158,7 @@ namespace DateTime.Widgets {
         GridDay update_day (GridDay day, GLib.DateTime new_date, GLib.DateTime today, GLib.DateTime month_start) {
             if (new_date.get_day_of_year () == today.get_day_of_year () && new_date.get_year () == today.get_year ()) {
                 day.name = "today";
+                day.get_style_context ().add_class ("today");
                 day.set_receives_default (true);
             }
             if (new_date.get_month () == month_start.get_month ()) {

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2011-2015 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2011–2018 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,10 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
     const string DAY_CSS = """
         .circular {
             border-radius: 50%;
+        }
+        
+        .accent {
+            font-weight: bold;
         }
     """;
 


### PR DESCRIPTION
Fixes #76. This separates the concerns of a focused date versus today, which could help reduce the confusion I've had in the indicator.