### PR TITLE
Focus today on opened

### DIFF
--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -105,6 +105,8 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         if (!start.equal (calmodel.month_start))
             calmodel.month_start = start;
         sync_with_model ();
+
+        grid.set_focus_to_today ();
     }
 
     //--- Signal Handlers ---//

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -69,6 +69,24 @@ namespace DateTime.Widgets {
             }
         }
 
+        public void set_focus_to_today () {
+            debug ("set_focus_to_today");
+            if (grid_range == null) return;
+            debug ("  found grid_range");
+            Gee.List<GLib.DateTime> dates = grid_range.to_list ();
+            int i = 0;
+            for (i = 0; i < dates.size; i++) {
+                var date = dates[i];
+                GridDay? day = data[day_hash (date)];
+                if (day != null && day.name == "today") {
+                    debug ("  found today");
+                    debug ("  can_focus: %s", day.can_focus? "true" : "false");
+                    day.grab_focus_force ();
+                    return;
+                }
+            }
+        }
+
         /**
          * Sets the given range to be displayed in the grid. Note that the number of days
          * must remain the same.

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -70,17 +70,14 @@ namespace DateTime.Widgets {
         }
 
         public void set_focus_to_today () {
-            debug ("set_focus_to_today");
-            if (grid_range == null) return;
-            debug ("  found grid_range");
+            if (grid_range == null) {
+                return;
+            }
             Gee.List<GLib.DateTime> dates = grid_range.to_list ();
-            int i = 0;
-            for (i = 0; i < dates.size; i++) {
+            for (int i = 0; i < dates.size; i++) {
                 var date = dates[i];
                 GridDay? day = data[day_hash (date)];
                 if (day != null && day.name == "today") {
-                    debug ("  found today");
-                    debug ("  can_focus: %s", day.can_focus? "true" : "false");
                     day.grab_focus_force ();
                     return;
                 }
@@ -179,7 +176,7 @@ namespace DateTime.Widgets {
             if (grid_range == null) return;
             Gee.List<GLib.DateTime> dates = grid_range.to_list ();
             var today = new GLib.DateTime.now_local ();
-            
+
             int i = 0;
             for (i = 0; i < dates.size; i++) {
                 var date = dates[i];
@@ -188,7 +185,7 @@ namespace DateTime.Widgets {
                 update_today_style (day, date, today);
             }
         }
-        
+
         public void update_today_style (GridDay day, GLib.DateTime date, GLib.DateTime today) {
             if (date.get_day_of_year () == today.get_day_of_year () && date.get_year () == today.get_year ()) {
                 day.name = "today";

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -90,6 +90,10 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
             set_state_flags (Gtk.StateFlags.NORMAL, true);
         }
     }
+    public void grab_focus_force () {
+        valid_grab = true;
+        grab_focus ();
+    }
     public override void grab_focus () {
         if (valid_grab) {
             base.grab_focus ();


### PR DESCRIPTION
Selects / focuses in on today when opened. 
Fixes: https://github.com/elementary/wingpanel-indicator-datetime/issues/102