### PR TITLE
Reset events on month change

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-08-03 08:24-0700\n"
-"PO-Revision-Date: 2018-09-28 00:07+0000\n"
-"Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
+"PO-Revision-Date: 2018-11-10 23:36+0000\n"
+"Last-Translator: Nils K <slx@nilsk.net>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.elementary.io/projects/"
 "wingpanel/wingpanel-indicator-datetime/nb/>\n"
 "Language: nb\n"
@@ -29,7 +29,6 @@ msgstr "Innstillinger for dato og tid …"
 
 #: src/Widgets/calendar/ControlHeader.vala:30
 #: src/Widgets/calendar/ControlHeader.vala:33
-#, fuzzy
 msgid "%OB %Y"
 msgstr "%OB %Y"
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,7 +96,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         if (event_grid != null) {
             event_grid.destroy ();
         }
-
+        if (calendar.selected_date == null) return false;
         var events = Widgets.CalendarModel.get_default ().get_events (calendar.selected_date);
         if (events.size == 0) return false;
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,10 +96,13 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         if (event_grid != null) {
             event_grid.destroy ();
         }
-        if (calendar.selected_date == null) return false;
+        if (calendar.selected_date == null){
+            return false;
+        }
         var events = Widgets.CalendarModel.get_default ().get_events (calendar.selected_date);
-        if (events.size == 0) return false;
-
+        if (events.size == 0) {
+            return false;
+        }
         event_grid = new Gtk.Grid ();
         event_grid.orientation = Gtk.Orientation.VERTICAL;
         main_grid.attach (event_grid, 0, 1);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,7 +96,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         if (event_grid != null) {
             event_grid.destroy ();
         }
-        if (calendar.selected_date == null){
+        if (calendar.selected_date == null) {
             return false;
         }
         var events = Widgets.CalendarModel.get_default ().get_events (calendar.selected_date);

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -121,6 +121,9 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
             return; // nothing to do
 
         sync_with_model ();
+        
+        selected_date = null;
+        selection_changed (selected_date);
     }
 
     //--- Helper Methods ---//


### PR DESCRIPTION
Fixes #105 

By resetting selected_date.

Events are otherwise not cleared when navigating between months. 