### PR TITLE
Calendar: don't use absolute path or error silently

### DIFF
--- a/src/Widgets/calendar/Calendar.vala
+++ b/src/Widgets/calendar/Calendar.vala
@@ -19,8 +19,6 @@
 
 namespace DateTime.Widgets {
     public class Calendar : Gtk.Box {
-        private const string CALENDAR_EXEC = "/usr/bin/io.elementary.calendar";
-
         ControlHeader heading;
         CalendarView cal;
         public signal void selection_changed (GLib.DateTime? new_date);
@@ -63,14 +61,20 @@ namespace DateTime.Widgets {
 
         // TODO: As far as maya supports it use the Dbus Activation feature to run the calendar-app.
         public void show_date_in_maya (GLib.DateTime date) {
-            var iso_date_string = date.format ("%F");
-            var command = CALENDAR_EXEC + @" --show-day $iso_date_string";
+            var command = "io.elementary.calendar --show-day %s".printf (date.format ("%F"));
 
             try {
                 var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.NONE);
                 appinfo.launch_uris (null, null);
             } catch (GLib.Error e) {
-                warning ("Unable to start calendar, error: %s", e.message);
+                var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                    _("Unable To Launch Calendar"),
+                    _("The program \"io.elementary.calendar\" may not be installed"),
+                    "dialog-error"
+                );
+                dialog.show_error_details (e.message);
+                dialog.run ();
+                dialog.destroy ();
             }
         }
     }


### PR DESCRIPTION
Fixes #116 

Throws a dialog on error instead of leaving users in the dark:

![Screenshot from 2019-03-09 16 38 01@2x](https://user-images.githubusercontent.com/7277719/54079091-41e5a580-428a-11e9-935b-03c34d2e47e0.png)
