### PR TITLE
Re-depend on GNOME schema for date and time format

### DIFF
--- a/data/io.elementary.desktop.wingpanel.datetime.gschema.xml
+++ b/data/io.elementary.desktop.wingpanel.datetime.gschema.xml
@@ -1,35 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <enum id="io.elementary.desktop.wingpanel.datetime.clock-formats">
-    <value nick="12h" value="0" />
-    <value nick="24h" value="1" />
-    <value nick="ISO8601" value="2" />
-  </enum>
     <schema path="/io/elementary/desktop/wingpanel/datetime/" id="io.elementary.desktop.wingpanel.datetime">
         <key type="b" name="show-weeks">
             <default>false</default>
             <summary>Show week numbers.</summary>
             <description>If this is set to true, week numbers will be shown in the calendar.</description>
         </key>
-        <key name="clock-format" enum="io.elementary.desktop.wingpanel.datetime.clock-formats">
-            <default>"12h"</default>
-            <summary>Whether the clock displays in 12h or 24h format</summary>
-            <description>Whether the clock displays in 12h or 24h format</description>
-        </key>
-        <key type="b" name="clock-show-seconds">
-            <default>false</default>
-            <summary>If this is set to true, seconds will be shown in the clock</summary>
-            <description>If this is set to true, seconds will be shown in the clock</description>
-        </key>
-        <key type="b" name="clock-show-date">
-            <default>true</default>
-            <summary>If this is set to true, the date will be shown in the clock</summary>
-            <description>If this is set to true, the date will be shown in the clock</description>
-        </key>
-        <key type="b" name="clock-show-weekday">
-            <default>true</default>
-            <summary>If this is set to true, the day of the week will be shown in the clock</summary>
-            <description>If this is set to true, the day of the week will be shown in the clock</description>
+        <key type="s" name="custom-date-format">
+            <default>""</default>
+            <summary>Custom date format string</summary>
+            <description>Uses GLib.DateTime.format to render the date, use for instance %F for ISO8601 date</description>
         </key>
     </schema>
 </schemalist>

--- a/src/Services/TimeManager.vala
+++ b/src/Services/TimeManager.vala
@@ -42,7 +42,7 @@ public class DateTime.Services.TimeManager : Gtk.Calendar {
 
         add_timeout ();
         try {
-            var clock_settings = new GLib.Settings ("io.elementary.desktop.wingpanel.datetime");
+            var clock_settings = new GLib.Settings ("org.gnome.desktop.interface");
             clock_settings.bind ("clock-show-seconds", this, "clock-show-seconds", SettingsBindFlags.DEFAULT);
 
             notify["clock-show-seconds"].connect (() => {
@@ -130,7 +130,7 @@ public class DateTime.Services.TimeManager : Gtk.Calendar {
         return (uint)seconds_until_next_minute * 1000;
     }
 
-    public static TimeManager get_default () {
+    public static unowned TimeManager get_default () {
         if (instance == null) {
             instance = new TimeManager ();
         }


### PR DESCRIPTION
All the features are still there.