### PR TITLE
Calendar: GObject-style

### DIFF
--- a/src/Widgets/calendar/Calendar.vala
+++ b/src/Widgets/calendar/Calendar.vala
@@ -45,20 +45,16 @@ namespace DateTime.Widgets {
             cal.selection_changed.connect ((date) => {
                 selection_changed (date);
             });
-
             cal.on_event_add.connect ((date) => {
                 show_date_in_maya (date);
                 day_double_click (date);
             });
-
             heading.left_clicked.connect (() => {
                 CalendarModel.get_default ().change_month (-1);
             });
-
             heading.right_clicked.connect (() => {
                 CalendarModel.get_default ().change_month (1);
             });
-
             heading.center_clicked.connect (() => {
                 cal.today ();
             });

--- a/src/Widgets/calendar/Calendar.vala
+++ b/src/Widgets/calendar/Calendar.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2011-2019 elementary, Inc. (https://elementary.io)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -18,41 +18,50 @@
  */
 
 namespace DateTime.Widgets {
-    public class Calendar : Gtk.Box {
-        ControlHeader heading;
-        CalendarView cal;
+    public class Calendar : Gtk.Grid {
         public signal void selection_changed (GLib.DateTime? new_date);
         public signal void day_double_click (GLib.DateTime date);
 
-        public GLib.DateTime? selected_date { get {
-                return cal.selected_date;
-            } set {
-            }}
+        private CalendarView cal;
+        private ControlHeader heading;
 
-        public Calendar () {
-            Object (orientation: Gtk.Orientation.VERTICAL, halign: Gtk.Align.CENTER, valign: Gtk.Align.CENTER, can_focus: false);
-            this.margin_start = 10;
-            this.margin_end = 10;
+        public GLib.DateTime? selected_date {
+            get {
+                return cal.selected_date;
+            }
+        }
+
+        construct {
             heading = new ControlHeader ();
+            heading.margin = 6;
+
             cal = new CalendarView ();
+
+            margin_start = margin_end = 10;
+            orientation = Gtk.Orientation.VERTICAL;
+            add (heading);
+            add (cal);
+
             cal.selection_changed.connect ((date) => {
                 selection_changed (date);
             });
+
             cal.on_event_add.connect ((date) => {
                 show_date_in_maya (date);
                 day_double_click (date);
             });
+
             heading.left_clicked.connect (() => {
                 CalendarModel.get_default ().change_month (-1);
             });
+
             heading.right_clicked.connect (() => {
                 CalendarModel.get_default ().change_month (1);
             });
+
             heading.center_clicked.connect (() => {
                 cal.today ();
             });
-            add (heading);
-            add (cal);
         }
 
         public void show_today () {

--- a/src/Widgets/calendar/Calendar.vala
+++ b/src/Widgets/calendar/Calendar.vala
@@ -23,7 +23,6 @@ namespace DateTime.Widgets {
         public signal void day_double_click (GLib.DateTime date);
 
         private CalendarView cal;
-        private ControlHeader heading;
 
         public GLib.DateTime? selected_date {
             get {
@@ -32,7 +31,7 @@ namespace DateTime.Widgets {
         }
 
         construct {
-            heading = new ControlHeader ();
+            var heading = new ControlHeader ();
             heading.margin = 6;
 
             cal = new CalendarView ();

--- a/src/Widgets/calendar/ControlHeader.vala
+++ b/src/Widgets/calendar/ControlHeader.vala
@@ -49,8 +49,6 @@ namespace DateTime.Widgets {
             box_buttons.add (right_button);
 
             column_spacing = 6;
-            margin = 6;
-            margin_bottom = 0;
             add (label);
             add (box_buttons);
 


### PR DESCRIPTION
* Subclass Gtk.Grid instead of Box
* Fix `selected_date`
* Explicitly scope variables
* GObject-style construction
* Remove useless properties
* Organize