### PR TITLE
Make event labels smarter

### DIFF
--- a/src/Event.vala
+++ b/src/Event.vala
@@ -26,6 +26,11 @@ public class DateTime.Event : GLib.Object {
     public GLib.DateTime end_time;
     public bool day_event = false;
 
+    // For ListBox use.
+    public string event_times;
+    public string all_day_str;
+    public string alarm_str;
+
     private bool alarm = false;
 
     public Event (GLib.DateTime date, Util.DateRange range, iCal.Component component) {
@@ -44,18 +49,15 @@ public class DateTime.Event : GLib.Object {
         } else if (Util.is_the_all_day (start_time, end_time)) {
             day_event = true;
         }
+
+        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+        all_day_str = "%s".printf (_("All Day:"));
+        alarm_str = "%s".printf (_("Alarm:"));
     }
 
     public string get_label () {
         var summary = component.get_summary ();
-        if (day_event) {
-            return "%s\n%s".printf (summary, _("All Day"));
-        } else if (alarm) {
-            return "%s %s\n%s".printf (_("Alarm:"), start_time.format (Util.TimeFormat ()), summary);
-        } else if (range.days > 0 && date.compare (range.first_dt) != 0) {
-            return summary;
-        }
-        return "%s\n%s - %s".printf (summary, start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+        return summary;
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -46,12 +46,12 @@ public class DateTime.Event : GLib.Object {
         }
     }
 
-    public void get_event_label (out string summary) {
-        summary = component.get_summary ();
+    public string get_event_label () {
+        return component.get_summary ();
     }
 
-    public void get_event_times (out string event_times) {
-        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+    public string get_event_times () {
+        return "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -44,9 +44,6 @@ public class DateTime.Event : GLib.Object {
     }
 
     public string get_icon () {
-        if (alarm) {
-            return "alarm-symbolic";
-        }
         return "office-calendar-symbolic";
     }
 }

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -51,6 +51,9 @@ public class DateTime.Event : GLib.Object {
     }
 
     public string get_event_times () {
+        if (day_event) {
+            return "";
+        }
         return "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -46,9 +46,12 @@ public class DateTime.Event : GLib.Object {
         }
     }
 
-    public void get_label (out string summary, out string event_times) {
+    public void get_event_label (out string summary) {
         summary = component.get_summary ();
-        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+    }
+
+    public void get_event_times (out string event_times) {
+        summary = component.get_summary ();
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -23,6 +23,7 @@ public class DateTime.Event : GLib.Object {
     public Util.DateRange range { get; construct; }
 
     public GLib.DateTime start_time;
+    public GLib.DateTime end_time;
     public bool day_event = false;
 
     private bool alarm = false;

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -54,7 +54,7 @@ public class DateTime.Event : GLib.Object {
         if (day_event) {
             return "";
         }
-        return "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+        return "%s - %s".printf (start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -51,7 +51,7 @@ public class DateTime.Event : GLib.Object {
     }
 
     public void get_event_times (out string event_times) {
-        summary = component.get_summary ();
+        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -48,13 +48,13 @@ public class DateTime.Event : GLib.Object {
     public string get_label () {
         var summary = component.get_summary ();
         if (day_event) {
-            return summary;
+            return "%s\n%s".printf (summary, _("All Day"));
         } else if (alarm) {
-            return "%s - %s".printf (start_time.format (Util.TimeFormat ()), summary);
+            return "%s %s\n%s".printf (_("Alarm:"), start_time.format (Util.TimeFormat ()), summary);
         } else if (range.days > 0 && date.compare (range.first_dt) != 0) {
             return summary;
         }
-        return "%s - %s".printf (summary, start_time.format (Util.TimeFormat ()));
+        return "%s\n%s - %s".printf (summary, start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -26,11 +26,6 @@ public class DateTime.Event : GLib.Object {
     public GLib.DateTime end_time;
     public bool day_event = false;
 
-    // For ListBox use.
-    public string event_times;
-    public string all_day_str;
-    public string alarm_str;
-
     private bool alarm = false;
 
     public Event (GLib.DateTime date, Util.DateRange range, iCal.Component component) {
@@ -41,23 +36,11 @@ public class DateTime.Event : GLib.Object {
         );
     }
 
-    construct {
-        GLib.DateTime end_time;
-        Util.get_local_datetimes_from_icalcomponent (component, out start_time, out end_time);
-        if (end_time == null) {
-            alarm = true;
-        } else if (Util.is_the_all_day (start_time, end_time)) {
-            day_event = true;
-        }
-
-        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
-        all_day_str = "%s".printf (_("All Day:"));
-        alarm_str = "%s".printf (_("Alarm:"));
-    }
-
     public string get_label () {
+        Util.get_local_datetimes_from_icalcomponent (component, out start_time, out end_time);
         var summary = component.get_summary ();
-        return summary;
+        var event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
+        return summary + "\n" + event_times;
     }
 
     public string get_icon () {

--- a/src/Event.vala
+++ b/src/Event.vala
@@ -36,14 +36,25 @@ public class DateTime.Event : GLib.Object {
         );
     }
 
-    public string get_label () {
+    construct {
         Util.get_local_datetimes_from_icalcomponent (component, out start_time, out end_time);
-        var summary = component.get_summary ();
-        var event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
-        return summary + "\n" + event_times;
+
+        if (end_time == null) {
+            alarm = true;
+        } else if (Util.is_the_all_day (start_time, end_time)) {
+            day_event = true;
+        }
+    }
+
+    public void get_label (out string summary, out string event_times) {
+        summary = component.get_summary ();
+        event_times = "%s - %s".printf(start_time.format (Util.TimeFormat ()), end_time.format (Util.TimeFormat ()));
     }
 
     public string get_icon () {
+        if (alarm) {
+            return "alarm-symbolic";
+        }
         return "office-calendar-symbolic";
     }
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -128,13 +128,12 @@ public class DateTime.Indicator : Wingpanel.Indicator {
 
             var menuitem_times = new Gtk.Label ("");
             menuitem_times.set_markup ("<small>%s</small>".printf (e.get_event_times ()));
-            menuitem_times.hexpand = true;
-            menuitem_times.lines = 3;
             menuitem_times.ellipsize = Pango.EllipsizeMode.END;
             menuitem_times.max_width_chars = 30;
             menuitem_times.wrap = true;
             menuitem_times.wrap_mode = Pango.WrapMode.WORD_CHAR;
             menuitem_times.xalign = 0;
+            menuitem_times.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             var menuitem_box = new Gtk.Grid ();
             menuitem_box.margin_end = 6;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -127,7 +127,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             menuitem_label.xalign = 0;
 
             var menuitem_times = new Gtk.Label ("");
-            menuitem_times.set_markup (e.get_event_times ());
+            menuitem_times.set_markup ("<small>%s</small>".printf (e.get_event_times ()));
             menuitem_times.hexpand = true;
             menuitem_times.lines = 3;
             menuitem_times.ellipsize = Pango.EllipsizeMode.END;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -116,11 +116,8 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             var menuitem_icon = new Gtk.Image.from_icon_name (e.get_icon (), Gtk.IconSize.MENU);
             menuitem_icon.valign = Gtk.Align.START;
 
-            string label, times;
-            e.get_event_label (out label);
-            e.get_event_times (out times);
             var menuitem_label = new Gtk.Label ("");
-            menuitem_label.set_markup ("<b>%s</b>\n%s".printf(label, times));
+            menuitem_label.set_markup ("<b>%s</b>".printf(e.get_event_label ()));
             menuitem_label.hexpand = true;
             menuitem_label.lines = 3;
             menuitem_label.ellipsize = Pango.EllipsizeMode.END;
@@ -129,11 +126,22 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             menuitem_label.wrap_mode = Pango.WrapMode.WORD_CHAR;
             menuitem_label.xalign = 0;
 
-            var menuitem_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
+            var menuitem_times = new Gtk.Label ("");
+            menuitem_times.set_markup (e.get_event_times ());
+            menuitem_times.hexpand = true;
+            menuitem_times.lines = 3;
+            menuitem_times.ellipsize = Pango.EllipsizeMode.END;
+            menuitem_times.max_width_chars = 30;
+            menuitem_times.wrap = true;
+            menuitem_times.wrap_mode = Pango.WrapMode.WORD_CHAR;
+            menuitem_times.xalign = 0;
+
+            var menuitem_box = new Gtk.Grid ();
             menuitem_box.margin_end = 6;
             menuitem_box.margin_start = 6;
-            menuitem_box.add (menuitem_icon);
-            menuitem_box.add (menuitem_label);
+            menuitem_box.attach (menuitem_icon, 0, 0);
+            menuitem_box.attach (menuitem_label, 1, 0);
+            menuitem_box.attach (menuitem_times, 1, 1);
 
             var menuitem = new Gtk.Button ();
             menuitem.add (menuitem_box);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -128,11 +128,6 @@ public class DateTime.Indicator : Wingpanel.Indicator {
 
             var menuitem_times = new Gtk.Label ("");
             menuitem_times.set_markup ("<small>%s</small>".printf (e.get_event_times ()));
-            menuitem_times.ellipsize = Pango.EllipsizeMode.END;
-            menuitem_times.max_width_chars = 30;
-            menuitem_times.wrap = true;
-            menuitem_times.wrap_mode = Pango.WrapMode.WORD_CHAR;
-            menuitem_times.xalign = 0;
             menuitem_times.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             var menuitem_box = new Gtk.Grid ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -116,7 +116,10 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             var menuitem_icon = new Gtk.Image.from_icon_name (e.get_icon (), Gtk.IconSize.MENU);
             menuitem_icon.valign = Gtk.Align.START;
 
-            var menuitem_label = new Gtk.Label (e.get_label ());
+            string label, times;
+            e.get_label (out label, out times);
+            var menuitem_label = new Gtk.Label ("");
+            menuitem_label.set_markup ("<b>%s</b>\n%s".printf(label, times));
             menuitem_label.hexpand = true;
             menuitem_label.lines = 3;
             menuitem_label.ellipsize = Pango.EllipsizeMode.END;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -117,7 +117,8 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             menuitem_icon.valign = Gtk.Align.START;
 
             string label, times;
-            e.get_label (out label, out times);
+            e.get_event_label (out label);
+            e.get_event_times (out times);
             var menuitem_label = new Gtk.Label ("");
             menuitem_label.set_markup ("<b>%s</b>\n%s".printf(label, times));
             menuitem_label.hexpand = true;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -128,6 +128,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
 
             var menuitem_times = new Gtk.Label ("");
             menuitem_times.set_markup ("<small>%s</small>".printf (e.get_event_times ()));
+            menuitem_times.xalign = 0;
             menuitem_times.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             var menuitem_box = new Gtk.Grid ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -141,7 +141,9 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             menuitem_box.margin_start = 6;
             menuitem_box.attach (menuitem_icon, 0, 0);
             menuitem_box.attach (menuitem_label, 1, 0);
-            menuitem_box.attach (menuitem_times, 1, 1);
+            if (!e.day_event) {
+                menuitem_box.attach (menuitem_times, 1, 1);
+            }
 
             var menuitem = new Gtk.Button ();
             menuitem.add (menuitem_box);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -117,7 +117,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             menuitem_icon.valign = Gtk.Align.START;
 
             var menuitem_label = new Gtk.Label ("");
-            menuitem_label.set_markup ("<b>%s</b>".printf(e.get_event_label ()));
+            menuitem_label.set_markup ("<b>%s</b>".printf (e.get_event_label ()));
             menuitem_label.hexpand = true;
             menuitem_label.lines = 3;
             menuitem_label.ellipsize = Pango.EllipsizeMode.END;


### PR DESCRIPTION
Instead of not showing via their labels, make shown:
- All-Day events
- Alarms
- End times of events that span times