### PR TITLE
Event: Remove get_event_label

### DIFF
--- a/src/Event.vala
+++ b/src/Event.vala
@@ -47,10 +47,6 @@ public class DateTime.Event : GLib.Object {
         }
     }
 
-    public string get_event_label () {
-        return component.get_summary ();
-    }
-
     public string get_event_times () {
         if (is_allday) {
             return "";

--- a/src/Widgets/EventRow.vala
+++ b/src/Widgets/EventRow.vala
@@ -38,7 +38,7 @@ public class DateTime.EventRow : Gtk.ListBoxRow {
         var event_image_context = event_image.get_style_context ();
         event_image_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var name_label = new Gtk.Label (cal_event.get_event_label ());
+        var name_label = new Gtk.Label (cal_event.component.get_summary ());
         name_label.hexpand = true;
         name_label.ellipsize = Pango.EllipsizeMode.END;
         name_label.lines = 3;


### PR DESCRIPTION
Seems silly to have this method since component is already public and this does nothing but return get_summary