### PR TITLE
Fix calendar scroll

### DIFF
--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -185,10 +185,18 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
 
         double dir = 0.0;
         bool natural_scroll;
+        var source_device = e.get_source_device ();
         var event_source = e.get_source_device ().input_source;
-        if (event_source == Gdk.InputSource.MOUSE) {
+
+        /* Fallback to device name to try to detect a touch device that reports itself as a mouse */
+        bool is_touchpad = (event_source == Gdk.InputSource.TOUCHPAD ||
+                           source_device.get_name ().up ().contains ("TOUCH"));
+
+        bool is_mouse = !is_touchpad && (event_source == Gdk.InputSource.MOUSE);
+
+        if (is_mouse) {
             natural_scroll = natural_scroll_mouse;
-        } else if (event_source == Gdk.InputSource.TOUCHPAD) {
+        } else if (is_touchpad) {
             natural_scroll = natural_scroll_touchpad;
         } else {
             natural_scroll = false;
@@ -197,10 +205,11 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         switch (e.direction) {
             case Gdk.ScrollDirection.SMOOTH:
             /* Mouse events may also be SMOOTH */
-                if (event_source == Gdk.InputSource.MOUSE) {
+                if (is_mouse) {
                     e.delta_x *= DELTA_PER_MONTH;
                     e.delta_y *= DELTA_PER_MONTH;
                 }
+
                 var abs_x = double.max (e.delta_x.abs (), 0.0001);
                 var abs_y = double.max (e.delta_y.abs (), 0.0001);
 

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -81,7 +81,6 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         // Signals and handlers
         button_press_event.connect (on_button_press);
         key_press_event.connect (on_key_press);
-        scroll_event.connect ((event) => {return Util.on_scroll_event (event);});
 
         notify["date"].connect (() => {
             label.label = date.get_day_of_month ().to_string ();

--- a/src/Widgets/calendar/Util.vala
+++ b/src/Widgets/calendar/Util.vala
@@ -20,48 +20,6 @@
  */
 
 namespace Util {
-    static bool has_scrolled = false;
-    const uint interval = 500;
-
-    public bool on_scroll_event (Gdk.EventScroll event) {
-        double delta_x;
-        double delta_y;
-        event.get_scroll_deltas (out delta_x, out delta_y);
-
-        double choice = delta_x;
-
-        if (((int)delta_x).abs () < ((int)delta_y).abs ()) {
-            choice = delta_y;
-        }
-
-        /* It's mouse scroll ! */
-        if (choice == 1 || choice == -1) {
-            DateTime.Widgets.CalendarModel.get_default ().change_month ((int)choice);
-
-            return true;
-        }
-
-        if (has_scrolled == true) {
-            return true;
-        }
-
-        if (choice > 0.3) {
-            reset_timer.begin ();
-            DateTime.Widgets.CalendarModel.get_default ().change_month (1);
-
-            return true;
-        }
-
-        if (choice < -0.3) {
-            reset_timer.begin ();
-            DateTime.Widgets.CalendarModel.get_default ().change_month (-1);
-
-            return true;
-        }
-
-        return false;
-    }
-
     public GLib.DateTime get_start_of_month (owned GLib.DateTime? date = null) {
         if (date == null) {
             date = new GLib.DateTime.now_local ();
@@ -544,14 +502,5 @@ namespace Util {
     /* Returns true if 'a' and 'b' are the same E.Source */
     public bool source_equal_func (E.Source a, E.Source b) {
         return a.dup_uid () == b.dup_uid ();
-    }
-
-    public async void reset_timer () {
-        has_scrolled = true;
-        Timeout.add (interval, () => {
-            has_scrolled = false;
-
-            return false;
-        });
     }
 }


### PR DESCRIPTION
Fixes #38 

Import smooth-scrolling logic from wingpanel-indicator-sound to replace Util.on_scroll_event (). This gives a more even and controllable scrolling using mouse and touch.  Also respects natural scrolling settings.