### PR TITLE
CalendarView: listen specifically for datarange and simplify

### DIFF
--- a/src/Widgets/calendar/CalendarModel.vala
+++ b/src/Widgets/calendar/CalendarModel.vala
@@ -42,9 +42,6 @@ namespace DateTime.Widgets {
         public signal void events_updated (E.Source source, Gee.Collection<ECal.Component> events);
         public signal void events_removed (E.Source source, Gee.Collection<ECal.Component> events);
 
-        /* The month_start, num_weeks, or week_starts_on have been changed */
-        public signal void parameters_changed ();
-
         private E.SourceRegistry registry { get; private set; }
         private HashTable<string, ECal.Client> source_client;
         private HashTable<string, ECal.ClientView> source_view;
@@ -93,7 +90,6 @@ namespace DateTime.Widgets {
                 });
 
                 load_all_sources ();
-                parameters_changed ();
             } catch (GLib.Error error) {
                 critical (error.message);
             }
@@ -248,7 +244,6 @@ namespace DateTime.Widgets {
         private void on_parameter_changed () {
             compute_ranges ();
             load_all_sources ();
-            parameters_changed ();
         }
 
         private ECal.ClientView on_client_view_received (AsyncResult results, E.Source source, ECal.Client client) {

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -64,9 +64,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         stack.show_all ();
         stack.expand = true;
 
-        var model = CalendarModel.get_default ();
-        model.parameters_changed.connect (on_model_parameters_changed);
-
         stack.notify["transition-running"].connect (() => {
             if (stack.transition_running == false) {
                 stack.get_children ().foreach ((child) => {
@@ -86,17 +83,22 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         attach (box_buttons, 1, 0);
         attach (stack, 0, 1, 2);
 
-        CalendarModel.get_default ().parameters_changed.connect (() => {
-            var date = CalendarModel.get_default ().month_start;
-            label.set_label (date.format (_("%OB, %Y")));
+        var model = CalendarModel.get_default ();
+        model.notify["data-range"].connect (() => {
+            label.label = model.month_start.format (_("%OB, %Y"));
+
+            sync_with_model ();
+
+            selected_date = null;
+            selection_changed (selected_date);
         });
 
         left_button.clicked.connect (() => {
-            CalendarModel.get_default ().change_month (-1);
+            model.change_month (-1);
         });
 
         right_button.clicked.connect (() => {
-            CalendarModel.get_default ().change_month (1);
+            model.change_month (1);
         });
 
         center_button.clicked.connect (() => {
@@ -165,18 +167,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
     private void on_show_weeks_changed () {
         var model = CalendarModel.get_default ();
         weeks.update (model.data_range.first_dt, model.num_weeks);
-    }
-
-    /* Indicates the month has changed */
-    private void on_model_parameters_changed () {
-        var model = CalendarModel.get_default ();
-        if (grid.grid_range != null && model.data_range.equals (grid.grid_range))
-            return; // nothing to do
-
-        sync_with_model ();
-
-        selected_date = null;
-        selection_changed (selected_date);
     }
 
     /* Sets the calendar widgets to the date range of the model */


### PR DESCRIPTION
Since we're ignoring when anything other than data_range changes, listen to that directly

Also, don't listen to the same signal twice