### PR TITLE
Minor refactoring and improve the performance and reliability of event dots.

### DIFF
--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -40,8 +40,11 @@ namespace DateTime.Widgets {
         private Gtk.Label[] header_labels;
         private Gtk.Revealer[] week_labels;
 
-        construct {
+        static construct {
             model = Widgets.CalendarModel.get_default ();
+        }
+
+        construct {
             header_labels = new Gtk.Label[7];
             for (int c = 0; c < 7; c++) {
                 header_labels[c] = new Gtk.Label (null);
@@ -264,28 +267,27 @@ namespace DateTime.Widgets {
         private uint day_hash (GLib.DateTime date) {
             return date.get_year () * 10000 + date.get_month () * 100 + date.get_day_of_month ();
         }
-        
-                
-        public void add_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
+
+        private void add_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
             foreach (var component in events) {
-            
                 unowned ICal.Component ical = component.get_icalcomponent ();
                 ICal.Time? start_time = ical.get_dtstart ();
+                if (start_time == null) return;
                 time_t start_unix = start_time.as_timet ();
                 var t = new GLib.DateTime.from_unix_utc (start_unix);
                 var d_hash = day_hash (t);
                 if (data.has_key (d_hash)) {
-                    data[d_hash].add_dots (source, component.get_icalcomponent ());
+                    data[d_hash].add_dots (source, ical);
                 }
             }
         }
 
-        public void remove_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
+        private void remove_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
             foreach (var component in events) {
                 unowned ICal.Component ical = component.get_icalcomponent ();
                 var event_uid = ical.get_uid ();
-
                 ICal.Time? start_time = ical.get_dtstart ();
+                if (start_time == null) return;
                 time_t start_unix = start_time.as_timet ();
                 var t = new GLib.DateTime.from_unix_utc (start_unix);
                 var d_hash = day_hash (t);

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -43,7 +43,7 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
     }
 
     static construct {
-    
+
         provider = new Gtk.CssProvider ();
         provider.load_from_resource ("/io/elementary/desktop/wingpanel/datetime/GridDay.css");
     }

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -33,6 +33,7 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
     private static Gtk.CssProvider provider;
 
     private Gee.ArrayList<string> event_dots;
+    private Gee.HashMap<string, Gtk.Widget> dot_map;
     private Gtk.Grid event_grid;
     private Gtk.Label label;
     private bool valid_grab = false;
@@ -83,6 +84,7 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         });
 
         event_dots = new Gee.ArrayList<string> ();
+        dot_map = new Gee.HashMap<string, Gtk.Widget> ();
     }
 
 
@@ -122,9 +124,9 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
             return;
         }
 
-        var dot = event_grid.get_children ();
-        if (dot.length () > 0) {
-            dot.nth_data (0).destroy ();
+        var dot = dot_map[event_uid];
+        if (dot != null) {
+            dot.destroy ();
         }
     }
 


### PR DESCRIPTION
- Take some of the refactoring work done by @Dirli.
- Increase performance of indicator while scrolling. With no dots in the indicator, the scrolling is smooth between months. If dots are present, the performance takes a hit and is sluggish while moving. This seems to fix that issue.
- Improve reliability of dots showing up. In the case of 3 dots, sometimes the indicator would require a couple openings to show. In the case of 3 dots, oftentimes the indicator would not show 3 dots upon startup. This seems to make event dots appear more reliably for the user.