### PR TITLE
Grid: Fewer CalendarModel connections

### DIFF
--- a/data/datetime.appdata.xml.in
+++ b/data/datetime.appdata.xml.in
@@ -6,6 +6,12 @@
   <name>Date &amp; Time Indicator</name>
   <summary>The date and time indicator</summary>
   <releases>
+    <release version="2.2.4" date="2020-05-18" urgency="medium">
+      <description>
+        <p>Improved performance when switching months</p>
+        <p>Updated translations</p>
+      </description>
+    </release>
     <release version="2.2.3" date="2020-05-17" urgency="medium">
       <description>
         <p>Fix missing event dots in the calendar view</p>

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011–2019 elementary, Inc. (https://elementary.io)
+ * Copyright 2011–2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -39,6 +39,12 @@ namespace DateTime.Widgets {
         private Gtk.Label[] header_labels;
         private Gtk.Revealer[] week_labels;
 
+        private static Widgets.CalendarModel calendar_model;
+
+        static construct {
+            calendar_model = Widgets.CalendarModel.get_default ();
+        }
+
         construct {
             header_labels = new Gtk.Label[7];
             for (int c = 0; c < 7; c++) {
@@ -64,6 +70,40 @@ namespace DateTime.Widgets {
             data = new Gee.HashMap<uint, GridDay> ();
             events |= Gdk.EventMask.SCROLL_MASK;
             events |= Gdk.EventMask.SMOOTH_SCROLL_MASK;
+
+            calendar_model.events_added.connect (add_event_dots);
+            calendar_model.events_removed.connect (remove_event_dots);
+        }
+
+        private void add_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
+            foreach (var component in events) {
+                unowned ICal.Component ical = component.get_icalcomponent ();
+
+                var start_time = ical.get_dtstart ().as_timet ();
+                var date_time = new GLib.DateTime.from_unix_utc (start_time);
+                var date_hash = day_hash (date_time);
+
+                if (data.has_key (date_hash)) {
+                    data[date_hash].add_event_dot (source, ical);
+                }
+            }
+
+            show_all ();
+        }
+
+        private void remove_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
+            foreach (var component in events) {
+                unowned ICal.Component ical = component.get_icalcomponent ();
+
+                var start_time = ical.get_dtstart ().as_timet ();
+                var date_time = new GLib.DateTime.from_unix_utc (start_time);
+                var date_hash = day_hash (date_time);
+
+                if (data.has_key (date_hash)) {
+                    var event_uid = ical.get_uid ();
+                    data[date_hash].remove_event_dot (event_uid);
+                }
+            }
         }
 
         private void on_day_focus_in (GridDay day) {

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2011–2020 elementary, Inc. (https://elementary.io)
+ * Copyright 2011–2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2011–2018 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2011–2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -85,6 +85,10 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
     }
 
     public void add_event_dot (E.Source source, ICal.Component ical) {
+        if (event_dots.size >= 3) {
+            return;
+        }
+
         var event_uid = ical.get_uid ();
         if (!event_dots.has_key (event_uid)) {
             var event_dot = new Gtk.Image ();


### PR DESCRIPTION
Based on an idea from @Dirli and #216 by @ikarosdev

This greatly reduces the number of connections to the calendar model and noticeably improves performance when switching months

"Hide Whitespace Changes" to show that the only real changes in GridDay are deletions.