### PR TITLE
Prevent loading DateTime outside session

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -225,8 +225,14 @@ public class DateTime.Indicator : Wingpanel.Indicator {
     }
 }
 
-public Wingpanel.Indicator get_indicator (Module module) {
+public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
     debug ("Activating DateTime Indicator");
+
+    if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {
+        debug ("Wingpanel is not in session, not loading DateTime");
+        return null;
+    }
+
     var indicator = new DateTime.Indicator ();
 
     return indicator;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -225,7 +225,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
     }
 }
 
-public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
+public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
     debug ("Activating DateTime Indicator");
 
     if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {


### PR DESCRIPTION
Noticed this in https://github.com/elementary/greeter/pull/450 https://github.com/elementary/greeter/pull/450#issuecomment-655130041. I tested that this indicator doesn't show in the greeter now in a vm.