### PR TITLE
Fix issues related to the use of Hdy.Carousel

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -161,7 +161,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         return 0;
     }
 
-    private void update_events_model (E.Source source, Gee.Collection<ECal.Component> events) {
+    private void update_events_model () {
         idle_update_events ();
     }
 
@@ -185,7 +185,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
 
         var date = calendar.selected_date;
 
-        var model = Widgets.CalendarModel.get_default ();
+        var model = calendar.current_calmodel;
 
         var events_on_day = new Gee.TreeMap<string, DateTime.EventRow> ();
 
@@ -210,16 +210,11 @@ public class DateTime.Indicator : Wingpanel.Indicator {
 
     public override void opened () {
         calendar.show_today ();
-
-        Widgets.CalendarModel.get_default ().events_added.connect (update_events_model);
-        Widgets.CalendarModel.get_default ().events_updated.connect (update_events_model);
-        Widgets.CalendarModel.get_default ().events_removed.connect (update_events_model);
+        calendar.events_changed.connect (update_events_model);
     }
 
     public override void closed () {
-        Widgets.CalendarModel.get_default ().events_added.disconnect (update_events_model);
-        Widgets.CalendarModel.get_default ().events_updated.disconnect (update_events_model);
-        Widgets.CalendarModel.get_default ().events_removed.disconnect (update_events_model);
+        calendar.events_changed.disconnect (update_events_model);
         calendar.clear ();
     }
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -49,9 +49,6 @@ public class DateTime.Indicator : Wingpanel.Indicator {
     }
 
     public override Gtk.Widget? get_widget () {
-
-        Hdy.init ();
-
         if (main_grid == null) {
             calendar = new Widgets.CalendarView ();
             calendar.margin_bottom = 6;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -220,6 +220,7 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         Widgets.CalendarModel.get_default ().events_added.disconnect (update_events_model);
         Widgets.CalendarModel.get_default ().events_updated.disconnect (update_events_model);
         Widgets.CalendarModel.get_default ().events_removed.disconnect (update_events_model);
+        calendar.clear ();
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -49,6 +49,9 @@ public class DateTime.Indicator : Wingpanel.Indicator {
     }
 
     public override Gtk.Widget? get_widget () {
+
+        Hdy.init ();
+
         if (main_grid == null) {
             calendar = new Widgets.CalendarView ();
             calendar.margin_bottom = 6;

--- a/src/Widgets/calendar/CalendarModel.vala
+++ b/src/Widgets/calendar/CalendarModel.vala
@@ -73,7 +73,6 @@ namespace DateTime.Widgets {
                     E.SourceCalendar cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
                     if (cal.selected == true && source.enabled == true) {
                         add_source_async.begin (source);
-                        add_source_async.begin (source);
                     }
                 });
 

--- a/src/Widgets/calendar/CalendarModel.vala
+++ b/src/Widgets/calendar/CalendarModel.vala
@@ -58,7 +58,7 @@ namespace DateTime.Widgets {
             return calendar_model;
         }
 
-        construct {
+        public CalendarModel calendar_model (GLib.DateTime date) {
             open.begin ();
 
             source_client = new HashTable<string, ECal.Client> (str_hash, str_equal);
@@ -132,14 +132,6 @@ namespace DateTime.Widgets {
             var events = source_events.get (source).get_values ().read_only_view;
             events_removed (source, events);
             source_events.remove (source);
-        }
-
-        public void change_month (int relative) {
-            month_start = month_start.add_months (relative);
-        }
-
-        public void change_year (int relative) {
-            month_start = month_start.add_years (relative);
         }
 
         /* --- Helper Methods ---// */

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -106,7 +106,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         });
 
         carousel.page_changed.connect ((index) => {
-            page_changed = true;
             if (position > index) {
                 rel_postion--;
                 position--;
@@ -151,8 +150,10 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
                 rel_postion++;
             }
             label.label = current_calmodel.month_start.format (_("%OB, %Y"));
+            page_changed = true;
         });
     }
+
     private void events_changed_sig () {
         events_changed ();
     }
@@ -162,17 +163,21 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
 
         grid.show_all ();
 
-        grid.on_event_add.connect ((date) => {
-            show_date_in_maya (date);
-            day_double_click ();
-        });
+        grid.on_event_add.connect (on_event_add_callback);
 
-        grid.selection_changed.connect ((date) => {
-            selected_date = date;
-            selection_changed (date);
-        });
+        grid.selection_changed.connect (selection_changed_callback);
 
         return grid;
+    }
+    
+    private void on_event_add_callback (GLib.DateTime date) {
+            show_date_in_maya (date);
+            day_double_click ();
+    }
+    
+    private void selection_changed_callback (GLib.DateTime date) {
+            selected_date = date;
+            selection_changed (date);
     }
 
     public void show_today () {
@@ -228,8 +233,8 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
     public void clear () {
         foreach (unowned Gtk.Widget grid in carousel.get_children ()) {
             carousel.remove (grid);
-           // ((DateTime.Widgets.Grid) grid).on_event_add.disconnect ();
-            //grid.selection_changed.disconnect ();
+            ((DateTime.Widgets.Grid) grid).on_event_add.disconnect (on_event_add_callback);
+            ((DateTime.Widgets.Grid) grid).selection_changed.disconnect (selection_changed_callback);
             ((DateTime.Widgets.Grid) grid).foreach ((day_grid) => ((DateTime.Widgets.Grid) grid).remove (day_grid));
             grid.destroy ();
         }

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -151,7 +151,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
                 calmodel.change_month (-1);
                 var grid = create_grid ();
                 grid.set_range (calmodel.data_range, calmodel.month_start);
-                grid.set_range (calmodel.data_range, calmodel.month_start);
                 grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
                 carousel.prepend (grid);
                 gridlist.prepend (grid);
@@ -160,7 +159,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
             }
             label.label = calmodel.month_start.format (_("%OB, %Y"));
         });
-
         show_today ();
     }
 
@@ -204,58 +202,47 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
     }
 
     private void set_carousel_grids () {
-            rel_postion = 0;
-            position = 1;
-            start_month = Util.get_start_of_month ();
-            calmodel.month_start = start_month;
+        rel_postion = 0;
+        position = 1;
+        start_month = Util.get_start_of_month ();
+        calmodel.month_start = start_month;
 
-            center_grid = create_grid ();
-            center_grid.set_range (calmodel.data_range, calmodel.month_start);
-            center_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
+        center_grid = create_grid ();
+        center_grid.set_range (calmodel.data_range, calmodel.month_start);
+        center_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
 
-            calmodel.change_month (-1);
-            left_grid = create_grid ();
-            left_grid.set_range (calmodel.data_range, calmodel.month_start);
-            left_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
+        calmodel.change_month (-1);
+        left_grid = create_grid ();
+        left_grid.set_range (calmodel.data_range, calmodel.month_start);
+        left_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
 
-            calmodel.change_month (2);
-            right_grid = create_grid ();
-            right_grid.set_range (calmodel.data_range, calmodel.month_start);
-            right_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
-            calmodel.change_month (-1);
+        calmodel.change_month (2);
+        right_grid = create_grid ();
+        right_grid.set_range (calmodel.data_range, calmodel.month_start);
+        right_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
+        calmodel.change_month (-1);
 
-            carousel.add (left_grid);
-            carousel.add (center_grid);
-            carousel.add (right_grid);
+        carousel.add (left_grid);
+        carousel.add (center_grid);
+        carousel.add (right_grid);
 
-            gridlist.append (left_grid);
-            gridlist.append (center_grid);
-            gridlist.append (right_grid);
+        gridlist.append (left_grid);
+        gridlist.append (center_grid);
+        gridlist.append (right_grid);
 
-            carousel.scroll_to (center_grid);
-            label.label = calmodel.month_start.format (_("%OB, %Y"));
-            current_grid = center_grid;
+        carousel.scroll_to (center_grid);
+        label.label = calmodel.month_start.format (_("%OB, %Y"));
+        current_grid = center_grid;
     }
 
     public void clear () {
-
-           foreach (unowned Gtk.Widget grid in carousel.get_children ()) {
-                carousel.remove (grid);
-                gridlist.remove ((DateTime.Widgets.Grid) grid);
-                grid.destroy ();
-            }
-            //calmodel.source_events.remove_all ();       /* foreach (unowned Grid grid in gridlist) {
-          /*  if ((grid != right_grid && grid != center_grid && grid != left_grid)) {
-                carousel.remove (grid);
-                gridlist.remove (grid);
-                grid.destroy ();
-            }
+        foreach (unowned Gtk.Widget grid in carousel.get_children ()) {
+            carousel.remove (grid);
+            gridlist.remove ((DateTime.Widgets.Grid) grid);
+            grid.destroy ();
         }
-        calmodel.change_month (-rel_postion);
-        carousel.switch_child (position, carousel.get_animation_duration ());
-        rel_postion = 0;
-        position = 1;*/
     }
+
     // TODO: As far as maya supports it use the Dbus Activation feature to run the calendar-app.
     public void show_date_in_maya (GLib.DateTime date) {
         var command = "io.elementary.calendar --show-day %s".printf (date.format ("%F"));

--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -133,7 +133,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
             selected_date = null;
             current_grid.events_changed.disconnect (events_changed_sig);
             current_grid = (DateTime.Widgets.Grid) carousel.get_children ().nth_data (index);
-            print("test");
             current_calmodel = current_grid.calmodel;
             current_grid.events_changed.connect (events_changed_sig);
             selection_changed (selected_date);
@@ -205,10 +204,8 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
 
         center_grid = create_grid ();
         rel_postion = -1;
-                print (center_grid.calmodel.month_start.format (_("%OB, %Y")));
         left_grid = create_grid ();
         rel_postion = 1;
-                        print (center_grid.calmodel.month_start.format (_("%OB, %Y")));
         right_grid = create_grid ();
         rel_postion = 0;
 
@@ -224,7 +221,6 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         current_calmodel = center_grid.calmodel;
         current_grid.events_changed.connect (events_changed_sig);
         label.label = center_grid.calmodel.month_start.format (_("%OB, %Y"));
-        print(label.label);
 
         carousel.show_all ();
     }

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -115,7 +115,12 @@ namespace DateTime.Widgets {
             day.set_selected (true);
             day.set_state_flags (Gtk.StateFlags.FOCUSED, false);
             selection_changed (selected_date);
+        }
 
+        public void remove_day_focus_in () {
+            if (selected_gridday != null) {
+                selected_gridday.set_selected (false);
+            }
         }
 
         public void set_focus_to_today () {
@@ -127,7 +132,10 @@ namespace DateTime.Widgets {
                 var date = dates[i];
                 GridDay? day = data[day_hash (date)];
                 if (day != null && day.name == "today") {
-                    day.grab_focus_force ();
+                    if (selected_gridday != day) {
+                        day.grab_focus_force ();
+                    }
+                day.set_selected (true);
                     return;
                 }
             }
@@ -180,7 +188,7 @@ namespace DateTime.Widgets {
                     /* Still update_day to get the color of etc. right */
                     day = update_day (new GridDay (new_date), new_date, today, month_start);
                     day.on_event_add.connect ((date) => on_event_add (date));
-                    day.focus_in_event.connect ((event) => {
+                    day.focus_grabbed.connect (() => {
                         on_day_focus_in (day);
 
                         return false;

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -34,15 +34,17 @@ namespace DateTime.Widgets {
 
         public signal void selection_changed (GLib.DateTime new_date);
 
+        public signal void events_changed ();
+
         private Gee.HashMap<uint, GridDay> data;
         private GridDay selected_gridday;
         private Gtk.Label[] header_labels;
         private Gtk.Revealer[] week_labels;
 
-        private static Widgets.CalendarModel calendar_model;
+        public Widgets.CalendarModel calmodel {get; private set;}
 
-        construct {
-            calendar_model = new Widgets.CalendarModel ();
+        public Grid (GLib.DateTime datetime) {
+            calmodel = new Widgets.CalendarModel (Util.get_start_of_month (datetime));
             header_labels = new Gtk.Label[7];
             for (int c = 0; c < 7; c++) {
                 header_labels[c] = new Gtk.Label (null);
@@ -66,8 +68,14 @@ namespace DateTime.Widgets {
 
             data = new Gee.HashMap<uint, GridDay> ();
 
-            calendar_model.events_added.connect (add_event_dots);
-            calendar_model.events_removed.connect (remove_event_dots);
+            calmodel.events_added.connect (add_event_dots);
+            calmodel.events_removed.connect (remove_event_dots);
+
+            calmodel.events_added.connect (() => (events_changed ()));
+            calmodel.events_removed.connect (() => (events_changed ()));
+            calmodel.events_updated.connect (() => (events_changed ()));
+
+            set_range ();
         }
 
         private void add_event_dots (E.Source source, Gee.Collection<ECal.Component> events) {
@@ -142,7 +150,7 @@ namespace DateTime.Widgets {
          * Sets the given range to be displayed in the grid. Note that the number of days
          * must remain the same.
          */
-        public void set_range (Util.DateRange new_range, GLib.DateTime month_start) {
+        private void set_range () {
             var today = new GLib.DateTime.now_local ();
 
             Gee.List<GLib.DateTime> old_dates;
@@ -153,7 +161,7 @@ namespace DateTime.Widgets {
                 old_dates = grid_range.to_list ();
             }
 
-            var new_dates = new_range.to_list ();
+            var new_dates = calmodel.data_range.to_list ();
 
             var data_new = new Gee.HashMap<uint, GridDay> ();
 
@@ -163,7 +171,7 @@ namespace DateTime.Widgets {
             /* Create new widgets for the new range */
 
             var date = Util.strip_time (today);
-            date = date.add_days (CalendarModel.get_default ().week_starts_on - date.get_day_of_week ());
+            date = date.add_days (calmodel.week_starts_on - date.get_day_of_week ());
             foreach (var label in header_labels) {
                 label.label = date.format ("%a");
                 date = date.add_days (1);
@@ -180,10 +188,10 @@ namespace DateTime.Widgets {
                     /* A widget already exists for this date, just change it */
 
                     var old_date = old_dates[i];
-                    day = update_day (data[day_hash (old_date)], new_date, today, month_start);
+                    day = update_day (data[day_hash (old_date)], new_date, today, calmodel.month_start);
                 } else {
                     /* Still update_day to get the color of etc. right */
-                    day = update_day (new GridDay (new_date), new_date, today, month_start);
+                    day = update_day (new GridDay (new_date), new_date, today,calmodel.month_start);
                     day.on_event_add.connect ((date) => on_event_add (date));
                     day.focus_grabbed.connect (() => {
                         on_day_focus_in (day);
@@ -213,7 +221,7 @@ namespace DateTime.Widgets {
             data.clear ();
             data.set_all (data_new);
 
-            grid_range = new_range;
+            grid_range = calmodel.data_range;
         }
 
         /**

--- a/src/Widgets/calendar/Grid.vala
+++ b/src/Widgets/calendar/Grid.vala
@@ -41,11 +41,8 @@ namespace DateTime.Widgets {
 
         private static Widgets.CalendarModel calendar_model;
 
-        static construct {
-            calendar_model = Widgets.CalendarModel.get_default ();
-        }
-
         construct {
+            calendar_model = new Widgets.CalendarModel ();
             header_labels = new Gtk.Label[7];
             for (int c = 0; c < 7; c++) {
                 header_labels[c] = new Gtk.Label (null);

--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -26,6 +26,7 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
      * Event emitted when the day is double clicked or the ENTER key is pressed.
      */
     public signal void on_event_add (GLib.DateTime date);
+    public signal bool focus_grabbed ();
 
     public GLib.DateTime date { get; construct set; }
 
@@ -79,6 +80,8 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
             label.label = date.get_day_of_month ().to_string ();
         });
 
+        focus_in_event.connect (() => focus_grabbed ());
+
         event_dots = new Gee.HashMap<string, Gtk.Widget> ();
     }
 
@@ -129,7 +132,7 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
 
     public override void grab_focus () {
         if (valid_grab) {
-            base.grab_focus ();
+            focus_grabbed ();
             valid_grab = false;
         }
     }


### PR DESCRIPTION
This PR addresses problems related to the use of libhandy for the calendar. #232

- [x] Properly update selected dates when switching months.
- [x] Rewrite CalendarModel in order to not perform unnecessary actions all the time #235 
- [ ] Free the memory, when closing the indicator. #235
 (I would appreciate help with the last one as I'm not able to get the memory freed. I try to free it in CalendarView.clear ().