### PR TITLE
Fixed an issue where focus style was not reset to today

### DIFF
--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -30,6 +30,7 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
     private int rel_postion;
     private CalendarModel calmodel;
     private GLib.DateTime start_month;
+    private DateTime.Widgets.Grid start_month_grid;
     private Gtk.Label label;
     private bool showtoday;
 
@@ -64,9 +65,9 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         calmodel = CalendarModel.get_default ();
         start_month = Util.get_start_of_month ();
 
-        var center_grid = create_grid ();
-        center_grid.set_range (calmodel.data_range, calmodel.month_start);
-        center_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
+        start_month_grid = create_grid ();
+        start_month_grid.set_range (calmodel.data_range, calmodel.month_start);
+        start_month_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
 
         calmodel.change_month (-1);
         var left_grid = create_grid ();
@@ -86,9 +87,9 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
         };
 
         carousel.add (left_grid);
-        carousel.add (center_grid);
+        carousel.add (start_month_grid);
         carousel.add (right_grid);
-        carousel.scroll_to (center_grid);
+        carousel.scroll_to (start_month_grid);
 
         position = 1;
         rel_postion = 0;
@@ -128,6 +129,7 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
                 rel_postion = 0;
                 position = (int) carousel.get_position ();
                 label.label = calmodel.month_start.format (_("%OB, %Y"));
+                start_month_grid.set_focus_to_today ();
                 return;
             } else {
                 calmodel.change_month (rel_postion);
@@ -193,9 +195,9 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
 
             start_month = Util.get_start_of_month ();
             calmodel.month_start = start_month;
-            var center_grid = create_grid ();
-            center_grid.set_range (calmodel.data_range, calmodel.month_start);
-            center_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
+            start_month_grid = create_grid ();
+            start_month_grid.set_range (calmodel.data_range, calmodel.month_start);
+            start_month_grid.update_weeks (calmodel.data_range.first_dt, calmodel.num_weeks);
 
             calmodel.change_month (-1);
             var left_grid = create_grid ();
@@ -209,9 +211,9 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
             calmodel.change_month (-1);
 
             carousel.add (left_grid);
-            carousel.add (center_grid);
+            carousel.add (start_month_grid);
             carousel.add (right_grid);
-            carousel.scroll_to (center_grid);
+            carousel.scroll_to (start_month_grid);
             label.label = calmodel.month_start.format (_("%OB, %Y"));
             carousel.no_show_all = false;
         }


### PR DESCRIPTION
Whenever we select another day than "today" and then click on the calendar icon to reset to "today", the rounded styling of the previously selected day is not removed - despite the fact, that the shown events are from today.

This PR fixes this issue.