### PR TITLE
utils: Workaround wrong ICal.Time.get_timezone() binding to fix memleak

### DIFF
--- a/src/Widgets/calendar/Util.vala
+++ b/src/Widgets/calendar/Util.vala
@@ -44,8 +44,6 @@ namespace Util {
 
         var tzid = date.get_tzid ();
         if (tzid == null) {
-            // In libical, null tzid means floating time
-            assert (date.get_timezone () == null);
             return new GLib.TimeZone.local ();
         }
 
@@ -73,24 +71,21 @@ namespace Util {
                 return new GLib.TimeZone (tzid);
             }
         }
+
+        //FIXME See https://github.com/libical/libical/pull/513
         // If tzid fails, try ICal.Time.get_timezone ()
-        unowned ICal.Timezone? timezone = null;
-        if (timezone == null && date.get_timezone () != null) {
-            timezone = date.get_timezone ();
-        }
-        // If timezone is still null), it's floating: set to local time
-        if (timezone == null) {
-            return new GLib.TimeZone.local ();
-        }
+        ICal.Timezone* timezone = date.get_timezone ();
 
         // Get UTC offset and format for GLib.TimeZone constructor
         int is_daylight;
-        int interval = timezone.get_utc_offset (date, out is_daylight);
+        int interval = timezone->get_utc_offset (date, out is_daylight);
         bool is_positive = interval >= 0;
         interval = interval.abs ();
         var hours = (interval / 3600);
         var minutes = (interval % 3600) / 60;
         var hour_string = "%s%02d:%02d".printf (is_positive ? "+" : "-", hours, minutes);
+
+        delete timezone;
 
         return new GLib.TimeZone (hour_string);
     }


### PR DESCRIPTION
See https://github.com/libical/libical/pull/513