### PR TITLE
Fix incorrect month shown on re-opening indicator if previously changed month (#283)

### DIFF
--- a/src/Widgets/calendar/CalendarView.vala
+++ b/src/Widgets/calendar/CalendarView.vala
@@ -216,7 +216,11 @@ public class DateTime.Widgets.CalendarView : Gtk.Grid {
             carousel.add (right_grid);
             carousel.scroll_to (start_month_grid);
             label.label = calmodel.month_start.format (_("%OB, %Y"));
+
+            position = 1;
+            rel_postion = 0;
         }
+
         carousel.no_show_all = false;
     }
 


### PR DESCRIPTION
Fixes #283 

Reset position and relative position after rebuilding carousel.

This was forgotten to be done in #280.