### PR TITLE
meson: require granite >= 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need the following dependencies:
 * libecal1.2-dev
 * libedataserver1.2-dev
 * libical-dev
-* libgranite-dev
+* libgranite-dev >= 6.0.0
 * libwingpanel-dev
 * meson
 * valac >= 0.40.3

--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ shared_module(
     dependencies: [
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite'),
+        dependency('granite', version: '>=6.0.0'),
         dependency('gtk+-3.0'),
         libecal_dep,
         dependency('libedataserver-1.2'),


### PR DESCRIPTION
Commit https://github.com/elementary/wingpanel-indicator-datetime/commit/1b8fa36c5a451de2cdad82db07bf569ffe1b8822 started using `Granite.TOOLTIP_SECONDARY_TEXT_MARKUP`, which was only added with granite 6.0.0.

This PR adds a `>= 6.0.0` requirement for granite to `meson.build` and updates `README.md` build dependencies as well. The `deb-packaging` branch might need a similar update.