### PR TITLE
GridDay: Do not connect to the notify signal for the property

### DIFF
--- a/src/Widgets/calendar/GridDay.vala
+++ b/src/Widgets/calendar/GridDay.vala
@@ -78,10 +78,11 @@ public class DateTime.Widgets.GridDay : Gtk.EventBox {
         // Signals and handlers
         button_press_event.connect (on_button_press);
         key_press_event.connect (on_key_press);
-
-        notify["date"].connect (() => {
-            label.label = date.get_day_of_month ().to_string ();
-        });
+        bind_property ("date", label, "label", GLib.BindingFlags.SYNC_CREATE, (binding, from_value, ref to_value) => {
+            unowned var new_date = (GLib.DateTime) from_value.get_boxed ();
+            to_value.take_string (new_date.get_day_of_month ().to_string ());
+            return true;
+        }, null);
 
         component_dots = new Gee.HashMap<string, Gtk.Widget> ();
     }


### PR DESCRIPTION
Use bind_property to make sure that it is synced on creation.

Fixes #303